### PR TITLE
Better handling of Firefox reloading

### DIFF
--- a/src/BrowserExtensionPlugin.ts
+++ b/src/BrowserExtensionPlugin.ts
@@ -5,14 +5,8 @@ import InjectPlugin, { ENTRY_ORDER } from 'webpack-inject-plugin'
 import WebSocket from 'ws'
 import { compileTemplate } from './compileTemplate'
 import type webpack from 'webpack'
+import { BrowserVendors } from './types'
 
-type BrowserVendors =
-  | 'chrome'
-  | 'safari'
-  | 'firefox'
-  | 'edge'
-  | 'opera'
-  | 'unknown'
 export class BrowserExtensionPlugin {
   vendor: BrowserVendors
   port: number
@@ -322,6 +316,7 @@ export class BrowserExtensionPlugin {
       isSecure: this.isSecure,
       // Firefox caching on programmatic injection is pretty strong so we need to clear it
       alwayFullReload: this.vendor === 'firefox' || hasManifestContentScripts,
+      vendor: this.vendor,
     })
 
     return client

--- a/src/client-background.ts
+++ b/src/client-background.ts
@@ -10,6 +10,8 @@ import { AnyPortMessage, AnyServerMessage, BrowserPort } from './types'
   const fileRegex = /[^"]*\.[a-zA-Z]+/g
   const extension = getWebExtensionApis()
   const connections: (chrome.runtime.Port | browser.runtime.Port)[] = []
+  const alwaysFullReload =
+    /* PLACEHOLDER-ALWAYSFULLRELOAD */ false /* PLACEHOLDER-ALWAYSFULLRELOAD */
 
   connect()
 
@@ -184,6 +186,10 @@ import { AnyPortMessage, AnyServerMessage, BrowserPort } from './types'
 
     if (!effectsEntry) {
       // Broadcast change to clients in case a files changed in them
+      if (alwaysFullReload) {
+        reloadExtension('always full reload on')
+        return
+      }
       broadcastMessage({ action: 'reload', changedFiles })
       log('ignoring update')
       return

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,3 +13,11 @@ export type AnyServerMessage = AnyUniversalMessage
 export type AnyPortMessage =
   | AnyUniversalMessage
   | { action: 'backgroundReload'; reason: string }
+
+export type BrowserVendors =
+  | 'chrome'
+  | 'safari'
+  | 'firefox'
+  | 'edge'
+  | 'opera'
+  | 'unknown'


### PR DESCRIPTION
### Description

Before this PR this library was painful to use with Firefox. It really did not work well due to the some of the behaviors of Firefox.

- Firefox does not allow you to reload only a script even when it is dynamically inject, due to cache.
- Firefox will not run `window.reload` scripts in a content script of an extension after the background has be reloaded. ( Probably a spam issue )

This fixes both of those by reloading the the background script, and also reloading the content scripts from the background page.

> There is times that I have reloaded the page and the dynamic injection does not inject ( race condition ), probably more of an issue with the app I am testing it with then this library.
